### PR TITLE
Fix for clearBtn to clear the current search query

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -1021,6 +1021,7 @@
                             clearTimeout(this.searchTimeout);
 
                             this.$filter.find('.multiselect-search').val('');
+                            this.query = '';
                             $('li', this.$ul).show().removeClass('multiselect-filter-hidden');
 
                             this.updateSelectAll();


### PR DESCRIPTION
When pressing the clear button, it doesn't reset the query that was last searched. So if you search for the same query again, the filter will not be applied. This change resets the query and fixes this issue.